### PR TITLE
Update crash prevention in the function _readSerial() 

### DIFF
--- a/Sim800l.cpp
+++ b/Sim800l.cpp
@@ -102,7 +102,11 @@ void Sim800l::setPhoneFunctionality(){
   SIM.print (F("AT+CFUN=1\r\n"));
 }
  //TODO: function sleep..
- // void Sim800l::sleep(){}
+ // void Sim800l::sleep(){
+ 	AT+CFUN=0; //MINF
+ 	
+ 	
+ }
 
 void Sim800l::signalQuality(){
 /*Response

--- a/Sim800l.cpp
+++ b/Sim800l.cpp
@@ -101,7 +101,8 @@ void Sim800l::setPhoneFunctionality(){
   */
   SIM.print (F("AT+CFUN=1\r\n"));
 }
-
+ //TODO: function sleep..
+ // void Sim800l::sleep(){}
 
 void Sim800l::signalQuality(){
 /*Response


### PR DESCRIPTION
Hello, 

I face one issue in _readSerial() function, and given solution below.

In detail, the function's return data type is String, you are returning data when available from serial port. But when GSM not working or not connected with serial port at that time function return nothing. We do not get compilation error, but when we call function for to perform certain String operation at that time controller get hang or crash.

Old function
```C++
String Sim800l::_readSerial()
{
   _timeout=0;
   while  (!SIM.available() && _timeout < 12000  )
   {
         delay(13);
         _timeout++;
   }
   if (SIM.available())
   {
        return SIM.readString();
   }
} 
```

New function(Added one line)

```C++
String Sim800l::_readSerial()
{
   _timeout=0;
   while  (!SIM.available() && _timeout < 12000  )
   {
         delay(13);
         _timeout++;
   }
   if (SIM.available())
   {
        return SIM.readString();
   }
   return "timeOut";
} 
```
I personally tested so, you can update and commit